### PR TITLE
Fix: Implemented manual model resolution for message starring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 
     "require": {
         "php": "^7.3|^8.0",
-        "andrew/laravel-chat-package": "dev-main",
+        "andrew/laravel-chat-package": "dev-master",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
         "laravel/framework": "^8.75",

--- a/composer.lock
+++ b/composer.lock
@@ -4,11 +4,11 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "630ccb5bce3713f6470612416d09e13e",
+    "content-hash": "4390ada5473b30a13d7484080cca38eb",
     "packages": [
         {
             "name": "andrew/laravel-chat-package",
-            "version": "dev-main",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "packages/andrew/laravel-chat-package",
@@ -7817,9 +7817,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "andrew/laravel-chat-package": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/packages/andrew/laravel-chat-package/config/chat.php
+++ b/packages/andrew/laravel-chat-package/config/chat.php
@@ -24,6 +24,13 @@ return [
     'tables' => [
         'conversations' => 'chat_conversations',
         'messages'      => 'chat_messages',
+        'participants'  => 'chat_participants',
+
+        'message_reads' => 'chat_message_reads',
+
+        'message_stars' => 'chat_message_stars',
+
+
     ],
 
     /*
@@ -31,7 +38,7 @@ return [
     | Broadcasting
     |--------------------------------------------------------------------------
     */
-   'broadcast' => [
+    'broadcast' => [
 
         'enabled' => true,
 

--- a/packages/andrew/laravel-chat-package/database/migrations/2024_01_01_000002_create_chat_messages_table.php
+++ b/packages/andrew/laravel-chat-package/database/migrations/2024_01_01_000002_create_chat_messages_table.php
@@ -17,7 +17,7 @@ class CreateChatMessagesTable extends Migration
                 /**
                  * Conversation reference
                  */
-                $table->unsignedBigInteger('conversation_id')->index();
+                $table->unsignedBigInteger('conversation_id')->index()->nullable(false);
 
                 /**
                  * Sender (do NOT foreign-key users table)

--- a/packages/andrew/laravel-chat-package/database/migrations/2025_12_16_000001_create_chat_message_stars.php
+++ b/packages/andrew/laravel-chat-package/database/migrations/2025_12_16_000001_create_chat_message_stars.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('chat_message_stars', function (Blueprint $table) {
+            $table->id();
+
+            $table->unsignedBigInteger('message_id')->index();
+            $table->unsignedBigInteger('user_id')->index();
+
+            $table->timestamps();
+
+            $table->unique(['message_id', 'user_id']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('chat_message_stars');
+    }
+};

--- a/packages/andrew/laravel-chat-package/src/Events/MessageStarToggled.php
+++ b/packages/andrew/laravel-chat-package/src/Events/MessageStarToggled.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Andrew\ChatPackage\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Queue\SerializesModels;
+
+class MessageStarToggled implements ShouldBroadcast
+{
+    use SerializesModels;
+
+    public function __construct(
+        public string $chatKey,
+        public array $payload
+    ) {}
+
+    public function broadcastOn(): Channel
+    {
+        return new Channel("chat.{$this->chatKey}");
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'message.star.toggled';
+    }
+}

--- a/packages/andrew/laravel-chat-package/src/Http/Controllers/MessageStarController.php
+++ b/packages/andrew/laravel-chat-package/src/Http/Controllers/MessageStarController.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Andrew\ChatPackage\Http\Controllers;
+
+use Andrew\ChatPackage\Events\MessageStarToggled;
+use Andrew\ChatPackage\Models\Message;
+use Andrew\ChatPackage\Services\StarMessageService;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class MessageStarController extends Controller
+{
+    public function __construct(
+        protected StarMessageService $service
+    ) {}
+
+    /**
+     * POST /chat/messages/{message}/star
+     */
+    public function store(Request $request, $message)
+    {
+
+        $message = Message::query()->findOrFail($message);
+        $userId = (int) $request->user()->id;
+        $this->authorizeStarAction($message, $userId);
+
+        $this->service->star($message->id, $userId);
+
+        event(new MessageStarToggled(
+            chatKey: $message->conversation->chat_key,
+            payload: [
+                'message_id'  => $message->id,
+                'user_id'     => $userId,
+                'starred'     => true,
+                'created_at'  => now()->toISOString(),
+            ]
+        ));
+
+        return response()->json([
+            'message_id' => $message->id,
+            'starred'    => true,
+        ]);
+    }
+
+    /**
+     * DELETE /chat/messages/{message}/star
+     */
+    public function destroy(Request $request, $message)
+    {
+        $message = Message::query()->findOrFail($message);
+        $userId = (int) $request->user()->id;
+
+        $this->authorizeStarAction($message, $userId);
+
+        $this->service->unstar($message->id, $userId);
+
+        event(new MessageStarToggled(
+            chatKey: $message->conversation->chat_key,
+            payload: [
+                'message_id'  => $message->id,
+                'user_id'     => $userId,
+                'starred'     => false,
+                'created_at'  => now()->toISOString(),
+            ]
+        ));
+
+        return response()->json([
+            'message_id' => $message->id,
+            'starred'    => false,
+        ]);
+    }
+
+    /**
+     * GET /chat/messages/starred?chat_key=...&limit=50
+     */
+    public function index(Request $request)
+    {
+        $userId = (int) $request->user()->id;
+        $limit  = (int) ($request->get('limit', 50));
+        $chatKey = $request->get('chat_key');
+
+        $messages = $this->service->listStarredForUser($userId, $limit, $chatKey);
+
+        // Optional: return minimal payload
+        return response()->json([
+            'data' => $messages->map(function (Message $m) use ($userId) {
+                return [
+                    'id'         => $m->id,
+                    'content'    => $m->content,
+                    'type'       => $m->type ?? 'text',
+                    'chat_key'   => $m->conversation?->chat_key,
+                    'starred'    => true,
+                    'created_at' => $m->created_at?->toISOString(),
+                ];
+            })->values(),
+        ]);
+    }
+
+    /**
+     * ✅ Ensure the user is a participant in the conversation that owns this message.
+     * (No dev needs to add policies.)
+     */
+    protected function authorizeStarAction(Message $message, int $userId): void
+    {
+        $message->loadMissing('conversation.participants');
+
+        $conversation = $message->conversation;
+
+        abort_unless($conversation, 404, 'Conversation not found for this message.');
+
+        abort_unless(
+            $conversation->participants->contains('user_id', $userId),
+            403,
+            'You are not a participant of this conversation.'
+        );
+    }
+}

--- a/packages/andrew/laravel-chat-package/src/Models/Message.php
+++ b/packages/andrew/laravel-chat-package/src/Models/Message.php
@@ -4,14 +4,14 @@ namespace Andrew\ChatPackage\Models;
 
 use Andrew\ChatPackage\Events\MessageSent;
 use Illuminate\Database\Eloquent\Model;
- use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Message extends Model
 {
     protected $table;
 
     protected $guarded = [];
- 
+
     public function __construct(array $attributes = [])
     {
         $this->table = config('chat.tables.messages');
@@ -19,12 +19,35 @@ class Message extends Model
     }
 
     public function conversation()
-    {
-        return $this->belongsTo(Conversation::class);
-    }
+{
+    return $this->belongsTo(
+        Conversation::class,
+        'conversation_id', // FK on chat_messages
+        'id'               // PK on chat_conversations
+    );
+}
 
-     public function reads(): HasMany
+    public function reads(): HasMany
     {
         return $this->hasMany(MessageRead::class, 'message_id');
     }
+    public function stars()
+    {
+        return $this->belongsToMany(
+            config('auth.providers.users.model'),
+            'chat_message_stars',
+            'message_id',
+            'user_id'
+        )->withTimestamps();
+    }
+
+    public function isStarredBy(int $userId): bool
+    {
+        return $this->stars()->where('user_id', $userId)->exists();
+    }
+    public function starredBy()
+{
+    return $this->stars();
+}
+
 }

--- a/packages/andrew/laravel-chat-package/src/Routes/api.php
+++ b/packages/andrew/laravel-chat-package/src/Routes/api.php
@@ -8,6 +8,7 @@ use Andrew\ChatPackage\Http\Controllers\ConversationListController;
 use Andrew\ChatPackage\Http\Controllers\MessageController;
 use Andrew\ChatPackage\Http\Controllers\ConversationTypingController;
 use Andrew\ChatPackage\Http\Controllers\ConversationReadController;
+use Andrew\ChatPackage\Http\Controllers\MessageStarController;
 
 Route::middleware(['auth:sanctum'])->group(function () {
 
@@ -67,4 +68,25 @@ Route::middleware(['auth:sanctum'])->group(function () {
 
   // Send message
   Route::post('/chat/messages', [MessageController::class, 'store']);
+
+
+
+
+
+
+
+  /*
+|--------------------------------------------------------------------------
+| Message Stars
+|--------------------------------------------------------------------------
+*/
+
+Route::post('/chat/messages/{message}/star', [MessageStarController::class, 'store']);
+Route::delete('/chat/messages/{message}/star', [MessageStarController::class, 'destroy']);
+
+// List starred messages (optional: filter by chat_key)
+Route::get(
+    '/chat/messages/starred',
+    [\Andrew\ChatPackage\Http\Controllers\MessageStarController::class, 'index']
+);
 });

--- a/packages/andrew/laravel-chat-package/src/Services/MessageService.php
+++ b/packages/andrew/laravel-chat-package/src/Services/MessageService.php
@@ -11,7 +11,7 @@ class MessageService
     public function send(string $chatKey, int $userId, string $content): array
     {
         $conversation = Conversation::where('chat_key', $chatKey)
-            ->whereHas('participants', fn ($q) => $q->where('user_id', $userId))
+            ->whereHas('participants', fn($q) => $q->where('user_id', $userId))
             ->firstOrFail();
 
         $message = Message::create([
@@ -37,5 +37,21 @@ class MessageService
         ));
 
         return $payload;
+    }
+
+
+
+    public function star(int $messageId, int $userId): void
+    {
+        $message = Message::findOrFail($messageId);
+
+        $message->stars()->syncWithoutDetaching([$userId]);
+    }
+
+    public function unstar(int $messageId, int $userId): void
+    {
+        $message = Message::findOrFail($messageId);
+
+        $message->stars()->detach($userId);
     }
 }

--- a/packages/andrew/laravel-chat-package/src/Services/StarMessageService.php
+++ b/packages/andrew/laravel-chat-package/src/Services/StarMessageService.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Andrew\ChatPackage\Services;
+
+use Andrew\ChatPackage\Models\Message;
+use Illuminate\Database\Eloquent\Collection;
+
+class StarMessageService
+{
+    public function star(int $messageId, int $userId): Message
+    {
+        $message = Message::query()->findOrFail($messageId);
+
+        // idempotent
+        $message->starredBy()->syncWithoutDetaching([$userId]);
+
+        return $message;
+    }
+
+    public function unstar(int $messageId, int $userId): Message
+    {
+        $message = Message::query()->findOrFail($messageId);
+
+        $message->starredBy()->detach($userId);
+
+        return $message;
+    }
+
+    public function listStarredForUser(int $userId, int $limit = 50, ?string $chatKey = null): Collection
+    {
+        $query = Message::query()
+            ->whereHas('starredBy', fn ($q) => $q->where('user_id', $userId))
+            ->with(['conversation'])
+            ->latest()
+            ->limit($limit);
+
+        if ($chatKey) {
+            $query->whereHas('conversation', fn ($q) => $q->where('chat_key', $chatKey));
+        }
+
+        return $query->get();
+    }
+}


### PR DESCRIPTION
Summary
This merge adds support for starring chat messages, allowing users to mark and retrieve important messages easily.

Key Changes

Implemented message starring and unstarring functionality

Added chat_message_stars pivot table

Introduced StarMessageService for star logic (idempotent star/unstar)

Added authorization to ensure only conversation participants can star messages

Avoided route model binding issues by resolving messages explicitly inside the controller

Added real-time broadcast event for star toggle (MessageStarToggled)

Why this approach

Manual model resolution improves package reliability and avoids route-binding edge cases in package contexts

Authorization logic is self-contained and requires no extra configuration from consuming applications

Designed to be zero-config and safe for reuse across different Laravel apps

Impact

No breaking changes

Backward compatible

Improves UX by enabling message bookmarking